### PR TITLE
Remove typo on title

### DIFF
--- a/src/components/AdminLTE.jsx
+++ b/src/components/AdminLTE.jsx
@@ -249,7 +249,6 @@ class AdminLTE extends Component {
                 <span className="logo-lg">
                   <b>
                     {titleBold}
-abc
                   </b>
                   {titlethin}
                 </span>


### PR DESCRIPTION
"abc" was present Between Titleshort bold and thin